### PR TITLE
bump upper version bound on base

### DIFF
--- a/tasty-coverage.cabal
+++ b/tasty-coverage.cabal
@@ -38,7 +38,7 @@ source-repository head
 
 common deps
     build-depends:
-        base >=4.16 && <4.21,
+        base >=4.16 && <5,
         tasty >= 1.4 && < 1.6
 
 library


### PR DESCRIPTION
This solves #21 . The 5 upper bound may be too permissive but i don't think any single bound smaller(ie. 4.23, 4.24, etc) is better.